### PR TITLE
Dockerization

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,3 @@
+node_modules
+npm-debug.log
+.env

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,14 @@
+FROM node:18
+WORKDIR /home
+# Install app dependencies
+# A wildcard is used to ensure both package.json AND package-lock.json are copied
+# where available (npm@5+)
+COPY package*.json ./
+RUN npm install
+
+COPY . .
+EXPOSE 3000
+
+RUN npm run build
+
+CMD node --enable-source-maps --experimental-specifier-resolution=node --no-warnings --loader ts-node/esm ./dist/server.js

--- a/config/default.json
+++ b/config/default.json
@@ -7,11 +7,14 @@
     "logoFilePath" : "resources/logo-server.webp"
   },
   "database": {
-    "host": "127.0.0.1",
+    "host": "nostrcheck-db",
     "user": "nostrcheck",
     "password": "nostrcheck",
     "database": "nostrcheck",
     "droptables": false
+  },
+  "redis": {
+    "host": "nostrcheck-redis"
   },
   "media" : {
     "tosURL" : "",

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,59 @@
+services:
+  nostrcheck-db:
+    image: mysql:5.7
+    container_name: nostrcheck-db
+    environment:
+      MYSQL_ROOT_HOST: "%"
+      MYSQL_ALLOW_EMPTY_PASSWORD: true
+      MYSQL_DATABASE: nostrcheck
+      MYSQL_USER: nostrcheck
+      MYSQL_PASSWORD: nostrcheck
+    volumes:
+      - .nostrcheck:/var/lib/mysql
+    networks:
+      default:
+    restart: always
+    healthcheck:
+      test: ["CMD", "mysqladmin" ,"ping", "-h", "localhost"]
+      interval: 5s
+      timeout: 5s
+      retries: 5
+      start_period: 360s
+  nostrcheck-redis:
+    image: redis:7.0.5-alpine3.16
+    container_name: nostrcheck-redis
+    volumes:
+      - cache:/data
+    command: redis-server --loglevel warning
+    networks:
+      default:
+    restart: always
+    healthcheck:
+      test: ['CMD', 'redis-cli', 'ping', '|', 'grep', 'PONG']
+      interval: 1s
+      timeout: 5s
+      retries: 5
+  nostrcheck-api:
+    build: .
+    container_name: nostrcheck-api
+    ports:
+      - 127.0.0.1:3000:3000
+    depends_on:
+      nostrcheck-redis:
+        condition: service_healthy
+      nostrcheck-db:
+        condition: service_healthy
+    restart: on-failure
+    networks:
+      default:
+
+networks:
+  default:
+    name: nostrcheck
+    ipam:
+      driver: default
+      config:
+        - subnet: 12.12.12.0/24
+
+volumes:
+  cache:

--- a/package.json
+++ b/package.json
@@ -10,7 +10,9 @@
     "build": "tsc",
     "lint": "eslint --ignore-path .gitignore . --ext .ts",
     "lint:fix": "npm run lint -- --fix",
-    "test": "vitest"
+    "test": "vitest",
+    "docker:compose:start": "BUILDKIT_PROGRESS=plain docker compose -f ./docker-compose.yml up --build --remove-orphans $@",
+    "docker:compose:start:detached": "docker compose -f ./docker-compose.yml up -d --build --remove-orphans $@"
   },
   "author": "https://github.com/quentintaranpino",
   "license": "apache-2.0",

--- a/readme.md
+++ b/readme.md
@@ -540,6 +540,55 @@ sudo nano config/default.json
  
 ```
 
+## Docker
+
+To start the app in the Docker for debugging or dev purposes:
+
+```
+npm run docker:compose:start
+```
+
+To start the app in the Docker for production, in detached mode:
+
+```
+npm run docker:compose:start:detached
+
+### NGINX Config
+
+When running with Docker on the fresh machine, the following NGINX config needs to be set
+
+File: \**/etc/nginx/sites-available/default*Execute the following code at once in the terminal, to update the NGINX config
+
+```
+cat <<'EOF' >> /etc/nginx/sites-available/default
+
+server {
+  server_name domain.com;
+
+  location / {
+    proxy_pass http://127.0.0.1:3000;
+    proxy_set_header Upgrade $http_upgrade;
+    proxy_set_header Connection 'upgrade';
+    proxy_set_header Host $host;
+    proxy_cache_bypass $http_upgrade;
+  }
+}
+```
+
+To enable SSL, certbot needs to be run for the domain:
+
+```
+sudo certbot --nginx --agree-tos -n -d domain.com
+```
+
+Restart the Nginx service
+
+```
+sudo service nginx restart
+
+```
+
+
 ## License
 
 MIT License (MIT)

--- a/readme.md
+++ b/readme.md
@@ -575,6 +575,7 @@ server {
     proxy_cache_bypass $http_upgrade;
   }
 }
+EOF
 ```
 
 To enable SSL, certbot needs to be run for the domain:

--- a/readme.md
+++ b/readme.md
@@ -552,6 +552,7 @@ To start the app in the Docker for production, in detached mode:
 
 ```
 npm run docker:compose:start:detached
+```
 
 ### NGINX Config
 

--- a/readme.md
+++ b/readme.md
@@ -558,7 +558,8 @@ npm run docker:compose:start:detached
 
 When running with Docker on the fresh machine, the following NGINX config needs to be set
 
-File: \**/etc/nginx/sites-available/default*Execute the following code at once in the terminal, to update the NGINX config
+In the file: **/etc/nginx/sites-available/default**  
+Execute the following code at once in the terminal, to update the NGINX config
 
 ```
 cat <<'EOF' >> /etc/nginx/sites-available/default

--- a/src/app.ts
+++ b/src/app.ts
@@ -9,6 +9,7 @@ const app = express();
 
 app.set("host", process.env.HOSTNAME ?? config.get('server.host'));
 app.set("port", process.env.PORT ?? config.get('server.port'));
+app.set("env", process.env.ENVIRONMENT ?? config.get('environment'))
 app.set("version", process.env.npm_package_version ?? "0.0");
 app.set(
 	"pubkey",

--- a/src/lib/redis.ts
+++ b/src/lib/redis.ts
@@ -3,9 +3,14 @@ import { createClient } from "redis";
 import { logger } from "../lib/logger.js";
 import { RegisteredUsernameResult } from "../interfaces/register.js";
 import { LightningUsernameResult } from "../interfaces/lightning.js";
+import config from "config";
 
 //Redis configuration
-const redisClient = createClient();
+const redisClient = createClient({
+	socket: {
+		host: config.get('redis.host') ?? 'localhost'
+	}
+});
 (async (): Promise<void> => {
 	redisClient.on("error", (error) =>{
 		logger.error(`There is a problem connecting to redis server, is redis-server package installed on your system? : ${error}`);


### PR DESCRIPTION
## Intent
For easier and non-conflicting deploys, I am adding app and it's dependency services to the container, as following:

- API - nostrcheck-api
- Redis - nostrcheck-redis
- MySQL - nostrcheck-db

Since they are part of the same docker-compose file and they use hostname to communicate with each other, ports can stay default, and they will not be in a collision with other docker containers.